### PR TITLE
Normalize agent outputs in math evaluator

### DIFF
--- a/scripts/report_accuracy.py
+++ b/scripts/report_accuracy.py
@@ -1,0 +1,63 @@
+"""Report accuracy of math agents on a dataset using gpt-oss-20b."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Callable, Dict, Any
+
+# Ensure src/ on the path for direct execution
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+import math_agent
+
+Row = Dict[str, Any]
+
+
+def _load_dataset(path: Path) -> list[Row]:
+    """Load JSONL dataset from ``path``."""
+    with path.open("r", encoding="utf-8") as fh:
+        return [json.loads(line) for line in fh]
+
+
+def _accuracy(rows: list[Row], evaluator: Callable[[Row, str], str], model: str) -> tuple[int, int]:
+    """Return number of correct predictions and total rows.
+
+    Any exception raised by ``evaluator`` is surfaced with row context so
+    authentication or connection issues don't silently pass as perfect
+    accuracy.
+    """
+    correct = 0
+    for idx, row in enumerate(rows, 1):
+        try:
+            if evaluator(row, model) == row["solution"]:
+                correct += 1
+        except Exception as exc:  # pragma: no cover - defensive
+            raise RuntimeError(f"evaluation failed for row {idx}: {row}") from exc
+    return correct, len(rows)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Report accuracy for math agents")
+    parser.add_argument("--dataset", default=str(Path(__file__).resolve().parents[1] / "datasets" / "sample.jsonl"))
+    parser.add_argument("--model", default="gpt-oss-20b")
+    args = parser.parse_args()
+
+    dataset_path = Path(args.dataset)
+    rows = _load_dataset(dataset_path)
+
+    print(f"Model: {args.model}")
+    print(f"Dataset: {dataset_path}")
+
+    for evaluator in (math_agent.evaluate_equation, math_agent.evaluate_equation_with_tools):
+        correct, total = _accuracy(rows, evaluator, args.model)
+        accuracy = correct / total if total else 0.0
+        print(f"{evaluator.__name__}: {correct}/{total} correct ({accuracy:.0%})")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/report_accuracy.py
+++ b/scripts/report_accuracy.py
@@ -1,12 +1,17 @@
-"""Report accuracy of math agents on a dataset using gpt-oss-20b."""
+"""Report accuracy of math agents on a dataset."""
 
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
-from typing import Callable, Dict, Any
+from typing import Any, Callable, Dict
+
+# Disable tracing before importing the Agents SDK to avoid telemetry calls that
+# require valid OpenAI credentials when using alternative gateways.
+os.environ.setdefault("OPENAI_AGENTS_DISABLE_TRACING", "true")
 
 # Ensure src/ on the path for direct execution
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))

--- a/src/math_agent.py
+++ b/src/math_agent.py
@@ -1,0 +1,110 @@
+"""Math agent utilities for evaluating arithmetic equations."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict
+
+from agents import Agent
+from agents.tool import function_tool
+
+from openai_client import setup_agent_runner
+
+
+async def _run_agent(agent: Agent, prompt: str, model_name: str) -> str:
+    """Execute ``agent`` against ``prompt`` using ``model_name``.
+
+    Parameters
+    ----------
+    agent:
+        The :class:`agents.Agent` to execute.
+    prompt:
+        Question or instruction for the agent.
+    model_name:
+        Name of the model to use.
+
+    Returns
+    -------
+    str
+        The agent's final output lowercased.
+    """
+    runner, run_config = setup_agent_runner()
+    run_config.model = model_name
+    result = await runner.run(agent, prompt, run_config=run_config)
+    output = str(result.final_output).strip().lower()
+    return output.rstrip(".!")
+
+
+def evaluate_equation(row: Dict[str, Any], model_name: str) -> str:
+    """Determine whether an equation is correct.
+
+    Parameters
+    ----------
+    row:
+        Dataset record containing an ``equation`` field.
+    model_name:
+        Identifier of the model to query.
+
+    Returns
+    -------
+    str
+        ``"correct"`` if the equation holds or ``"incorrect"`` otherwise.
+
+    Notes
+    -----
+    This simple version of the agent uses no tools and relies solely on the
+    model's reasoning capabilities.
+    """
+    agent = Agent(
+        name="math-judge",
+        instructions=(
+            "You are given an arithmetic equation. Respond with 'correct' if the "
+            "equation is true or 'incorrect' if it is false."
+        ),
+    )
+    return asyncio.run(_run_agent(agent, row["equation"], model_name))
+
+
+@function_tool
+def addition(a: int, b: int) -> int:
+    """Return the sum of ``a`` and ``b``."""
+    return a + b
+
+
+@function_tool
+def subtraction(a: int, b: int) -> int:
+    """Return the result of ``a`` minus ``b``."""
+    return a - b
+
+
+@function_tool
+def multiplication(a: int, b: int) -> int:
+    """Return the product of ``a`` and ``b``."""
+    return a * b
+
+
+def evaluate_equation_with_tools(row: Dict[str, Any], model_name: str) -> str:
+    """Determine whether an equation is correct using math tools.
+
+    Parameters
+    ----------
+    row:
+        Dataset record containing an ``equation`` field.
+    model_name:
+        Identifier of the model to query.
+
+    Returns
+    -------
+    str
+        ``"correct"`` if the equation holds or ``"incorrect"`` otherwise.
+    """
+    agent = Agent(
+        name="math-judge-tools",
+        instructions=(
+            "You are given an arithmetic equation. Use the available math tools "
+            "to compute results. Respond with 'correct' if the equation is true "
+            "or 'incorrect' if it is false."
+        ),
+        tools=[addition, subtraction, multiplication],
+    )
+    return asyncio.run(_run_agent(agent, row["equation"], model_name))

--- a/tests/test_agent_sdk.py
+++ b/tests/test_agent_sdk.py
@@ -18,11 +18,7 @@ MODEL_NAME = os.environ.get("MODEL_NAME", "gpt-oss-120b")
 
 @pytest.mark.integration
 def test_agent_hello_world():
-    try:
-        runner, run_config = setup_agent_runner()
-    except EnvironmentError:
-        pytest.skip("OPENAI_API_KEY not set; skipping integration test.")
-
+    runner, run_config = setup_agent_runner()
     agent = Agent(name="greeter", model=MODEL_NAME)
     result = runner.run_sync(agent, "Say 'hello world'.", run_config=run_config)
     text = result.final_output_as(str).lower()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -14,11 +14,7 @@ MODEL_NAME = os.environ.get("MODEL_NAME", "gpt-oss-120b")
 
 @pytest.mark.integration
 def test_hello_world():
-    try:
-        client = setup_openai_client()
-    except EnvironmentError:
-        pytest.skip("OPENAI_API_KEY not set; skipping integration test.")
-
+    client = setup_openai_client()
     response = client.chat.completions.create(
         model=MODEL_NAME,
         messages=[{"role": "user", "content": "Say 'hello world'."}],

--- a/tests/test_math_agent_integration.py
+++ b/tests/test_math_agent_integration.py
@@ -1,0 +1,24 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure src path
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+import math_agent  # noqa: E402
+
+MODEL_NAME = os.environ.get("MODEL_NAME", "gpt-oss-120b")
+DATASET_PATH = Path(__file__).resolve().parents[1] / "datasets" / "sample.jsonl"
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("evaluator", [math_agent.evaluate_equation, math_agent.evaluate_equation_with_tools])
+def test_sample_dataset(evaluator):
+    with open(DATASET_PATH, "r", encoding="utf-8") as fh:
+        rows = [json.loads(line) for line in fh]
+
+    for row in rows:
+        assert evaluator(row, MODEL_NAME) == row["solution"]

--- a/tests/test_math_agent_unit.py
+++ b/tests/test_math_agent_unit.py
@@ -1,0 +1,50 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+# Ensure src on path
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+import math_agent  # noqa: E402
+
+
+def test_evaluate_equation_no_tools(monkeypatch):
+    row = {"equation": "2 + 2 = 4"}
+
+    captured = {}
+
+    async def fake_run(agent, prompt, run_config=None):
+        captured["agent"] = agent
+        captured["prompt"] = prompt
+        return SimpleNamespace(final_output="correct")
+
+    def fake_setup_runner():
+        return SimpleNamespace(run=fake_run), SimpleNamespace(model=None)
+
+    monkeypatch.setattr(math_agent, "setup_agent_runner", fake_setup_runner)
+
+    result = math_agent.evaluate_equation(row, "gpt-test")
+    assert result == "correct"
+    assert captured["agent"].tools == []
+
+
+def test_evaluate_equation_with_tools(monkeypatch):
+    row = {"equation": "2 + 2 = 5"}
+
+    captured = {}
+
+    async def fake_run(agent, prompt, run_config=None):
+        captured["agent"] = agent
+        captured["prompt"] = prompt
+        return SimpleNamespace(final_output="incorrect")
+
+    def fake_setup_runner():
+        return SimpleNamespace(run=fake_run), SimpleNamespace(model=None)
+
+    monkeypatch.setattr(math_agent, "setup_agent_runner", fake_setup_runner)
+
+    result = math_agent.evaluate_equation_with_tools(row, "gpt-test")
+    assert result == "incorrect"
+    assert len(captured["agent"].tools) == 3


### PR DESCRIPTION
## Summary
- strip trailing punctuation from agent responses before evaluating
- keep integration tests passing when models add a period after "correct" or "incorrect"

## Testing
- `uv run pytest`
- `uv run python scripts/report_accuracy.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6d2285114832ba4799efc00dedca4